### PR TITLE
Add OCI image support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bot-env/
 /data/
+/token

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12
+
+RUN mkdir /voicely-ping
+
+WORKDIR /voicely-ping
+
+COPY ["voicely-ping.py", "README.md", "./legal", "requirements.txt", "./"]
+
+RUN pip install -r requirements.txt
+
+CMD ["python", "voicely-ping.py"]

--- a/voicely-ping.py
+++ b/voicely-ping.py
@@ -6,11 +6,8 @@ from typing import List
 import math
 from enum import Enum
 import datetime
+import sys
 # import datetime
-
-# Load bot token from file
-with open('../token', 'r') as file:
-    bot_token = file.read().strip()
 
 # Define intents
 intents = discord.Intents.default()
@@ -823,6 +820,20 @@ async def sync(ctx: commands.Context, guild: discord.Guild = None):
             command_list += f"\n- `/{command.name}`"
         await ctx.send(f"Commands synced globally:{command_list}\nPlease note it may take up to an hour to propagate globally.", reference=ctx.message, ephemeral=True)
 
+# Check token
+def get_token() -> str:
+    try:
+        with open('./token', 'r') as file:
+            token = file.read().strip()
+            if not token:
+                raise ValueError("The token file is empty. Make sure to put the token inside the token file.")
+                sys.exit(1)
+            return token
+    except FileNotFoundError as e:
+        raise FileNotFoundError("The token file wasn't found.") from e
+        sys.exit(1)
+    except Exception as e:
+        raise RuntimeError(f"An unexpected error occurred: {e}") from e
 
 # Run the bot with the loaded token
-bot.run(bot_token)
+bot.run(get_token())


### PR DESCRIPTION
# Goal
Add support to maintain and build OCI images easily to streamline updates and running of the bot.

# Changes
The following changes have been made:
- Replaced the `bot_token` variable with a new function called `get_token()`. This will fetch the token and output errors and quit the program to easily tell the container manager that the bots token isn't available. It also quits with 1 indicating an error.
- Changed the token file to be in the same directory as the project to make configuration of the container a bit more straight forward.
- Added the token file to `.gitignore` to make sure it's not being accidentally pushed.
- Added a `Dockerfile` to build OCI images off of.

# Todo

- [x] Change the token location to support persistent data. As I completely forgot about persisting data over updates and starting new containers!